### PR TITLE
Fix database voting flow and add participant page

### DIFF
--- a/app/api/voting/route.ts
+++ b/app/api/voting/route.ts
@@ -82,10 +82,14 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const sessionId = searchParams.get("sessionId")
+    let sessionId = searchParams.get("sessionId")
 
     if (!sessionId) {
-      return NextResponse.json({ success: false, message: "Session ID obrigatório" }, { status: 400 })
+      const active = await sql`SELECT id FROM voting_sessions WHERE status = 'voting' ORDER BY created_at DESC LIMIT 1`
+      if (active.length === 0) {
+        return NextResponse.json({ success: false, message: "Nenhuma sessão ativa" }, { status: 404 })
+      }
+      sessionId = String(active[0].id)
     }
 
     console.log("Buscando dados da sessão:", sessionId)

--- a/app/votar/page.tsx
+++ b/app/votar/page.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+interface Option {
+  id: string
+  title: string
+  example: string
+  description: string | null
+}
+
+export default function VotingPage() {
+  const [sessionId, setSessionId] = useState<number | null>(null)
+  const [options, setOptions] = useState<Option[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [voted, setVoted] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/voting")
+        const data = await res.json()
+        if (data.success) {
+          setSessionId(data.data.session.id)
+          setOptions(data.data.options)
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    load()
+  }, [])
+
+  const submit = async () => {
+    if (!selected || !sessionId) return
+    try {
+      await fetch("/api/voting", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "cast_vote",
+          sessionId,
+          voterName: "Anonymous",
+          optionId: selected,
+        }),
+      })
+      setVoted(true)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  if (!sessionId) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-700">Nenhuma votação ativa no momento.</p>
+      </div>
+    )
+  }
+
+  if (voted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-700 font-medium">Obrigado por votar!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-slate-50">
+      <Card className="max-w-md w-full p-6 space-y-4">
+        <h1 className="text-xl font-bold text-slate-900 text-center">Escolha sua opção</h1>
+        <div className="space-y-3">
+          {options.map((opt) => (
+            <button
+              key={opt.id}
+              onClick={() => setSelected(opt.id)}
+              className={`w-full text-left p-3 border rounded-md ${selected === opt.id ? "border-amber-500" : "border-slate-200"}`}
+            >
+              <div className="font-medium text-slate-900">{opt.title}</div>
+              <div className="text-slate-600 text-sm">{opt.example}</div>
+            </button>
+          ))}
+        </div>
+        <Button onClick={submit} disabled={!selected} className="w-full">
+          Enviar Voto
+        </Button>
+      </Card>
+    </div>
+  )
+}

--- a/components/dashboard/database-context.tsx
+++ b/components/dashboard/database-context.tsx
@@ -88,14 +88,10 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
 
           if (result.success) {
             setVotes(result.data.votes)
-
-            // Atualizar status dos votantes baseado nos votos reais
-            const updatedVoters = voters.map((voter) => {
-              const hasVoted = result.data.voterList.some((vote: any) =>
-                vote.voter_name.includes(voter.name.split(" ")[0]),
-              )
-              return { ...voter, hasVoted }
-            })
+            const updatedVoters = voters.map((voter, index) => ({
+              ...voter,
+              hasVoted: index < result.data.totalVotes,
+            }))
             setVoters(updatedVoters)
           }
         } catch (error) {
@@ -137,44 +133,10 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         setVotes({ optionA: 0, optionB: 0, optionC: 0 })
         setVoters((prev) => prev.map((voter) => ({ ...voter, hasVoted: false })))
         setFinalVotes(null)
-
-        // Simular votos chegando
-        simulateVotes(createResult.sessionId)
         console.log("Votação iniciada com sucesso!")
       }
     } catch (error) {
       console.error("Erro ao iniciar votação:", error)
-    }
-  }
-
-  const simulateVotes = async (sessionId: number) => {
-    const voterNames = voters.map((v) => v.name)
-    const options = ["optionA", "optionB", "optionC"]
-
-    // Simular votos em intervalos aleatórios
-    for (let i = 0; i < voterNames.length; i++) {
-      setTimeout(
-        async () => {
-          const randomOption = options[Math.floor(Math.random() * options.length)]
-
-          try {
-            await fetch("/api/voting", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                action: "cast_vote",
-                sessionId,
-                voterName: voterNames[i],
-                optionId: randomOption,
-              }),
-            })
-            console.log(`Voto simulado para ${voterNames[i]}: ${randomOption}`)
-          } catch (error) {
-            console.error("Erro ao simular voto:", error)
-          }
-        },
-        (i + 1) * (1500 + Math.random() * 2000),
-      ) // Intervalos de 1.5-3.5s
     }
   }
 

--- a/components/real-time-dashboard.tsx
+++ b/components/real-time-dashboard.tsx
@@ -17,7 +17,7 @@ type DashboardState = "waiting" | "voting" | "results" | "decision"
 export default function RealTimeDashboard() {
   const { totalVotes, startVoting, endVoting, resetVoting, dashboardState, setDashboardState } = useDatabase()
 
-  const [timeLeft, setTimeLeft] = useState(60)
+  const [timeLeft, setTimeLeft] = useState(600)
   const [showCountdown, setShowCountdown] = useState(false)
 
   useEffect(() => {
@@ -42,7 +42,7 @@ export default function RealTimeDashboard() {
     console.log("Botão Iniciar Votação clicado")
     try {
       await startVoting()
-      setTimeLeft(60)
+      setTimeLeft(600)
       setShowCountdown(true)
       console.log("Função startVoting executada com sucesso")
     } catch (error) {
@@ -97,7 +97,9 @@ export default function RealTimeDashboard() {
             {showCountdown && (
               <div className="flex items-center gap-2 bg-slate-100/80 backdrop-blur-md rounded-full px-3 md:px-4 py-1.5 border border-slate-200">
                 <Clock className="h-3 w-3 md:h-4 md:w-4 text-amber-600" />
-                <span className="font-mono font-bold text-slate-900 text-sm md:text-base">{timeLeft}s</span>
+                <span className="font-mono font-bold text-slate-900 text-sm md:text-base">
+                  {Math.floor(timeLeft / 60)}:{String(timeLeft % 60).padStart(2, "0")}
+                </span>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- handle active session if no sessionId is given to the voting API
- refresh voter status based on total vote count
- remove vote simulation and use 10‑minute countdown
- add a simple page for participants to vote

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684726208ae48323a73abf860cd4e48c